### PR TITLE
Allow users to log in without email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,7 +21,7 @@ class User < ApplicationRecord
     user ||= create(uid: uid)
     user.update({
       uid: uid,
-      email: email,
+      email: email || "",
       permissions: permissions
     }.merge(extra_fields))
     user


### PR DESCRIPTION
This fixes login for clean-state setup when SSO does not provide email addresses