### PR TITLE
Fix asset compilation step in production container build

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -54,6 +54,6 @@ RUN chown $CONTAINER_USER_NAME:$CONTAINER_USER_NAME $APP_PATH
 
 USER $CONTAINER_USER_NAME
 RUN yarn --immutable
-RUN SECRET_KEY_BASE=`bin/rake secret` bundle exec rake assets:precompile
+RUN DATABASE_URL=postgresql://db SECRET_KEY_BASE=`bin/rake secret` bundle exec rake assets:precompile
 
 CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]


### PR DESCRIPTION
Previously, the container build failed as there is no database.yml or `DATABASE_URL`. No database is actually needed for compilation step, so a dummy value is added